### PR TITLE
Variable "type_" name consistency

### DIFF
--- a/make/0.18.0/src/Extra/Result.elm
+++ b/make/0.18.0/src/Extra/Result.elm
@@ -8,8 +8,8 @@ decoder : Decoder x -> Decoder a -> Decoder (Result x a)
 decoder x a =
     Decode.field "type" Decode.string
         |> Decode.andThen
-            (\tipe ->
-                case tipe of
+            (\type_ ->
+                case type_ of
                     "Ok" ->
                         Decode.field "arg" a
                             |> Decode.map Ok


### PR DESCRIPTION
In the code for handling logs, the "type" is shadowed as `type_`. That seems better than `tipe`, so this makes them consistent.

**Please consider discussing complicated changes in [Slack](https://elmlang.slack.com/#ellie) [(join)](http://elmlang.herokuapp.com) or [via email](mailto:ellie-app@lukewestby.com) before submitting a PR**

### New Feature or UX change?

- Sign up for the Elm slack at http://elmlang.herokuapp.com and join the [#ellie channel](https://elmlang.slack.com/#ellie)
- Alternatively, send an email to ellie-app@lukewestby.com
- Have a conversation about your idea!
- New features and changes to Ellie's UX are considered thoroughly and carefully. An unannounced pull request is not the correct way to propose them! Ellie is managed in the same spirit as Elm itself. You can find out more in [this talk](https://www.youtube.com/watch?v=DSjbTC-hvqQ)


### Bug Fix?

- [ ] Reference the [issue](https://github.com/lukewestby/ellie/issues) your PR fixes
- [ ] If your PR fixes an unreported issue, please open an issue first so that maintainers can have a chance to understand whether a PR is needed or if a deeper problem exists
- [ ] If your fix includes a lot of changed lines or files then a maintainer may ask for a short explanation of why the changes your made are the best way to fix the problem

**Thank you for contributing by fixing a problem with Ellie!**


### Performance Improvement?

 - [ ] Please include performance measurements if you can!

**Thank you for contributing by making Ellie faster!**
