### PR TITLE
Allow FF keycode for Ctrl/Cmd

### DIFF
--- a/client/src/Data/Ellie/KeyCombo.elm
+++ b/client/src/Data/Ellie/KeyCombo.elm
@@ -9,6 +9,28 @@ type alias KeyCombo =
     }
 
 
+controlKeysCodes : List Int
+controlKeysCodes =
+    [ 91, 92, 93, 224 ]
+
+
+controlKey : Int -> Bool
+controlKey int =
+    controlKeysCodes
+        |> List.any ((==) int)
+
+
+shiftKeyCodes : List Int
+shiftKeyCodes =
+    [ 16 ]
+
+
+shiftKey : Int -> Bool
+shiftKey int =
+    shiftKeyCodes
+        |> List.any ((==) int)
+
+
 type Msg
     = ControlDown
     | ControlUp
@@ -22,18 +44,18 @@ subscriptions =
     Sub.batch
         [ Keyboard.downs
             (\code ->
-                if code == 91 || code == 93 then
+                if controlKey code then
                     ControlDown
-                else if code == 16 then
+                else if shiftKey code then
                     ShiftDown
                 else
                     NoOp
             )
         , Keyboard.ups
             (\code ->
-                if code == 91 || code == 93 then
+                if controlKey code then
                     ControlUp
-                else if code == 16 then
+                else if shiftKey code then
                     ShiftUp
                 else
                     NoOp

--- a/client/src/Data/Ellie/KeyCombo.elm
+++ b/client/src/Data/Ellie/KeyCombo.elm
@@ -1,6 +1,7 @@
 module Data.Ellie.KeyCombo exposing (..)
 
 import Keyboard
+import Set exposing (Set)
 
 
 type alias KeyCombo =
@@ -9,26 +10,26 @@ type alias KeyCombo =
     }
 
 
-controlKeysCodes : List Int
-controlKeysCodes =
-    [ 91, 92, 93, 224 ]
+controlKeyCodes : Set Int
+controlKeyCodes =
+    Set.fromList [ 91, 92, 93, 224 ]
 
 
 controlKey : Int -> Bool
-controlKey int =
-    controlKeysCodes
-        |> List.any ((==) int)
+controlKey code =
+    controlKeyCodes
+        |> Set.member code
 
 
-shiftKeyCodes : List Int
+shiftKeyCodes : Set Int
 shiftKeyCodes =
-    [ 16 ]
+    Set.singleton 16
 
 
 shiftKey : Int -> Bool
-shiftKey int =
+shiftKey code =
     shiftKeyCodes
-        |> List.any ((==) int)
+        |> Set.member code
 
 
 type Msg


### PR DESCRIPTION
Addresses #21

There seems to have been a previous preference for in-lining the code values. I'd be more than happy to update the PR to mirror that if it's the preferred style, it simply seemed to be getting a bit verbose in the one branch and I wanted both branches to look similar

[Reference for the Key codes](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#Non-printable_keys_(function_keys))