### PR TITLE
avoid using package version from elm-package.json

### DIFF
--- a/make/0.18.0/src/Elm/Package/Description.purs
+++ b/make/0.18.0/src/Elm/Package/Description.purs
@@ -140,9 +140,9 @@ isSaved name version =
   FileSystem.exists <| filePath name version
 
 
-save :: ∀ e x. Description -> Task (fileSystem :: FILESYSTEM | e) x Unit
-save description@(Description d) =
-  FileSystem.write (filePath d.name d.version) description
+save :: ∀ e x. Name -> Version -> Description -> Task (fileSystem :: FILESYSTEM | e) x Unit
+save name version description =
+  FileSystem.write (filePath name version) description
 
 
 load :: ∀ e. Name -> Version -> Task (fileSystem :: FILESYSTEM | e) FileSystem.Error Description

--- a/make/0.18.0/src/Pipeline/Install.purs
+++ b/make/0.18.0/src/Pipeline/Install.purs
@@ -47,7 +47,7 @@ saveFilesToStorage package@(Package { name, version }) { sources, artifacts, des
     (const (const (const unit)))
       <$> Package.saveSources package sources
       <*> Package.saveArtifacts package artifacts
-      <*> Description.save description
+      <*> Description.save name version description
       >>= (\_ -> Package.markAsSaved package)
       |> lmap (const (BM.PackageProblem <| "Failed to save " <> show package))
 

--- a/make/0.18.0/src/Pipeline/Install/Store.purs
+++ b/make/0.18.0/src/Pipeline/Install/Store.purs
@@ -65,6 +65,6 @@ getConstraints name version = do
         Description.fetch name version
           |> lmap (\error -> BM.PackageProblem ("Could not load elm-package.json for package " <> show name <> ": " <> show error))
 
-      _ <- try <| Description.save description
+      _ <- try <| Description.save name version description
 
       pure <| Tuple d.elmVersion d.dependencies

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "elm-css": "npm run elm-css:build && npm run elm-css:concat",
     "watch:elm-css": "nodemon --exec \"npm run elm-css\" --watch client/css -e elm",
     "watch:webpack": "webpack-dev-server --watch --config ./webpack.dev.config.js",
+    "watch:make": "cd ./make/0.18.0 && npm run watch",
     "watch": "run-p watch:**",
     "clean": "rm -rf ./build",
     "install:elm": "cd client && elm-package install --yes",


### PR DESCRIPTION
it turns out elm-package doesn't verify that the version in elm-package.json `on github` is correct during publishing. so you can push to master on your repo, tag it, and then locally bump your version number and publish. you never have to actually push your version change to github.

since the `version` property of elm-package.json isn't reliable, this pr stops using it