### PR TITLE
Allow searching for packages with 3 characters

### DIFF
--- a/assets/src/Pages/Editor/State/Actions.elm
+++ b/assets/src/Pages/Editor/State/Actions.elm
@@ -43,7 +43,7 @@ update msg model =
                 , Command.none
                 )
 
-            else if String.length query < 4 then
+            else if String.length query < 3 then
                 ( Packages { packagesModel | query = query }
                 , Command.none
                 )


### PR DESCRIPTION
For example the svg package - https://github.com/elm/svg - does not appear in the search for elm packages.